### PR TITLE
New API methods which were added for supporting privacy marker transactions

### DIFF
--- a/src/eth.js
+++ b/src/eth.js
@@ -82,6 +82,49 @@ function Eth(web3) {
         params: 1,
         inputFormatter: [web3.extend.formatters.inputAddressFormatter],
       },
+      /**
+       * @function distributePrivateTransaction
+       * @param {String} privateTxn Signed private transaction in hex format
+       * @param {Object} privateData Private data to send
+       * @param {String[]} privateData.privateFor An array of the recipients’ base64-encoded public keys.
+       * @param {String[]} [privateData.privateFrom] The sending party’s base64-encoded public key to use (Privacy Manager default if not provided).
+       * @param {Number} [privateData.privacyFlag=0] 0 for SP (default if not provided), 1 for PP, 3 for PSV
+       * @return {String} Transaction Manager hash to be used as a privacy marker transaction's `data` when externally signing..
+       */
+      {
+        name: "distributePrivateTransaction",
+        call: "eth_distributePrivateTransaction",
+        params: 2,
+      },
+      /**
+       * @function getPrivacyPrecompileAddress
+       * @return {String} Contract address for the privacy precompile in hex format.
+       */
+      {
+        name: "getPrivacyPrecompileAddress",
+        call: "eth_getPrivacyPrecompileAddress",
+        params: 0,
+      },
+      /**
+       * @function getPrivateTransactionByHash
+       * @param {String} hash Privacy marker transaction's hash in HEX format.
+       * @return {Transaction} private transaction (will be nil if caller is not a participant).
+       */
+      {
+        name: "getPrivateTransactionByHash",
+        call: "eth_getPrivateTransactionByHash",
+        params: 1,
+      },
+      /**
+       * @function getPrivateTransactionReceipt
+       * @param {String} hash Privacy marker transaction's hash in HEX format.
+       * @return {Receipt} private transaction receipt (will be nil if caller is not a participant).
+       */
+      {
+        name: "getPrivateTransactionReceipt",
+        call: "eth_getPrivateTransactionReceipt",
+        params: 1,
+      },
     ],
   });
   return web3;

--- a/tests/web3.eth.test.js
+++ b/tests/web3.eth.test.js
@@ -8,6 +8,7 @@ const {
   BLOCK_NUMBER,
   SIGNED_RLP,
   ORION_ADDRESS,
+  TRANSACTION_HASH,
 } = require("./tests-utils/constants");
 
 describe("web3.eth", () => {
@@ -164,6 +165,91 @@ describe("web3.eth", () => {
       }).toThrow(
         'Provided address "undefined" is invalid, the capitalization checksum test failed, or its an indrect IBAN address which can\'t be converted.'
       );
+    });
+  });
+
+  describe("web3.eth.distributePrivateTransaction", () => {
+    it("should call eth_distributePrivateTransaction", async () => {
+      let request;
+      mockHttpPost((data) => {
+        request = data;
+      });
+
+      await web3.eth.distributePrivateTransaction(SIGNED_RLP, {
+        privateFor: [ORION_ADDRESS],
+      });
+
+      expect(request.jsonrpc).toEqual("2.0");
+      expect(request.method).toEqual("eth_distributePrivateTransaction");
+      expect(request.params).toEqual([
+        SIGNED_RLP,
+        {
+          privateFor: [ORION_ADDRESS],
+        },
+      ]);
+    });
+
+    it("throw error when call eth_distributePrivateTransaction with no param", async () => {
+      await expect(() => {
+        return web3.eth.distributePrivateTransaction();
+      }).toThrow("Invalid number of parameters");
+    });
+  });
+
+  describe("web3.eth.getPrivacyPrecompileAddress", () => {
+    it("should call eth_getPrivacyPrecompileAddress", async () => {
+      let request;
+      mockHttpPost((data) => {
+        request = data;
+      });
+
+      await web3.eth.getPrivacyPrecompileAddress();
+
+      expect(request.jsonrpc).toEqual("2.0");
+      expect(request.method).toEqual("eth_getPrivacyPrecompileAddress");
+      expect(request.params).toEqual([]);
+    });
+  });
+
+  describe("web3.eth.getPrivateTransactionByHash", () => {
+    it("should call eth_getPrivateTransactionByHash", async () => {
+      let request;
+      mockHttpPost((data) => {
+        request = data;
+      });
+
+      await web3.eth.getPrivateTransactionByHash(TRANSACTION_HASH);
+
+      expect(request.jsonrpc).toEqual("2.0");
+      expect(request.method).toEqual("eth_getPrivateTransactionByHash");
+      expect(request.params).toEqual([TRANSACTION_HASH]);
+    });
+
+    it("throw error when call eth_getPrivateTransactionByHash with no param", async () => {
+      await expect(() => {
+        return web3.eth.getPrivateTransactionByHash();
+      }).toThrow("Invalid number of parameters");
+    });
+  });
+
+  describe("web3.eth.getPrivateTransactionReceipt", () => {
+    it("should call eth_getPrivateTransactionReceipt", async () => {
+      let request;
+      mockHttpPost((data) => {
+        request = data;
+      });
+
+      await web3.eth.getPrivateTransactionReceipt(TRANSACTION_HASH);
+
+      expect(request.jsonrpc).toEqual("2.0");
+      expect(request.method).toEqual("eth_getPrivateTransactionReceipt");
+      expect(request.params).toEqual([TRANSACTION_HASH]);
+    });
+
+    it("throw error when call eth_getPrivateTransactionReceipt with no param", async () => {
+      await expect(() => {
+        return web3.eth.getPrivateTransactionReceipt();
+      }).toThrow("Invalid number of parameters");
     });
   });
 });


### PR DESCRIPTION
New API methods which were added in PR https://github.com/ConsenSys/quorum/pull/1234:

- eth_distributePrivateTransaction
- eth_getPrivacyPrecompileAddress
- eth_getPrivateTransactionByHash
- eth_getPrivateTransactionReceipt
