### PR TITLE
fix(typescript): correct type for IDistributeRawTransaction.privateFor

### DIFF
--- a/src/typescript/index.d.ts
+++ b/src/typescript/index.d.ts
@@ -80,7 +80,7 @@ declare module "web3js-quorum" {
   }
 
   export interface IPtmSend extends IOptions {
-    readonly privateFor: string;
+    readonly privateFor: string[];
   }
 
   export interface IPtmStoreRaw extends IOptions {
@@ -303,7 +303,7 @@ declare module "web3js-quorum" {
   export interface IDistributeRawTransaction {
     readonly privateKey: string;
     readonly privateFrom: string;
-    readonly privateFor: string;
+    readonly privateFor: string[];
     readonly privacyGroupId: string;
     readonly nonce: string;
     readonly to: string;


### PR DESCRIPTION
Also fixes it for the `IPtmSend` interface in addition to `IDistributeRawTransaction`

Fixes #54

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>